### PR TITLE
Smaller arkadteamListItem text

### DIFF
--- a/src/components/listItems/ArkadTeamListItem.js
+++ b/src/components/listItems/ArkadTeamListItem.js
@@ -8,16 +8,16 @@ const styles = {
   image: {
     height: 60,
     width: 60,
-    marginRight: 8,
+    marginRight: 5,
     borderRadius: 30
   },
   infoContainer: { flexDirection: 'column', flex: 1 },
   title: {
     flex: 1,
-    fontSize: 16,
+    fontSize: 15,
     marginTop: 8
   },
-  subtitle: { flex: 1, fontSize: 14, color: global.subtitleColor, marginBottom: 8 }
+  subtitle: { flex: 1, fontSize: 13, color: global.subtitleColor, marginBottom: 8 }
 }
 
 


### PR DESCRIPTION
## Change description

Makes the arkadTeamListItem slightly smaller, mostly by reducing text size and also reducing margin a bit. Even on a smaller phone, the text should stay on two rows (all entries in arkad team will be the same size). 

## How to verify

Run on a small phone and make the arkad team screen only has text on two rows. 

## Issues fixed

#308 
