### PR TITLE
Rename camera to Scanner

### DIFF
--- a/src/Router.js
+++ b/src/Router.js
@@ -202,7 +202,7 @@ const MainStack = createBottomTabNavigator(
             screen: CameraContainer,
             navigationOptions: () => ({
               ...navigationOptions,
-              headerTitle: <SubtitleHeader title="Camera" subtitle="Scan the QR-code on a students flipcard" />
+              title: 'Scanner' 
             })
           }
         },


### PR DESCRIPTION
## Change description

Change route title for camerasceen

## How to verify

Go to the cameraScreen, make sure that there's no subtitle and that the title is "Scanner" instead.

## Issues fixed

#425 