### PR TITLE
Small fixes

### DIFF
--- a/src/actions/api.js
+++ b/src/actions/api.js
@@ -154,6 +154,7 @@ const fetchCommentStudentFailure = error => ({
 
 export const commentRateStudent = (studentId, rating, comment) => async (dispatch) => {
   var newComment = comment.replace(/[\r\n]/g, "%0A")
+  rating == 'not set' ? rating = 0 : rating
   dispatch(fetchCommentStudentRequest())
   const token = await AsyncStorage.getItem('token')
   return fetch(


### PR DESCRIPTION
## Change description

Solves the save bug. App was not able to save when rating was default 0. The API was returning default null ratings, the ratings were converted to 'not set' in the App. Changes the patch blips to recognize if rating is set to 'Not Set' and changes it to 0 then.

## How to verify

Comment a student without a rating and sucessfully save. 

## Issues fixed

-
